### PR TITLE
Update Cadillac CTS generations: Correct end year for second generation and add Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Cadillac CTS
 
+This repository contains signal set configurations for the Cadillac CTS, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Cadillac CTS.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Cadillac_CTS"
+
 generations:
   - name: "First Generation"
     start_year: 2003
@@ -6,8 +9,8 @@ generations:
 
   - name: "Second Generation"
     start_year: 2008
-    end_year: 2013
-    description: "The second-generation CTS grew in size, refinement, and performance, moving more firmly into the mid-size luxury segment. Built on an enhanced version of the Sigma platform, it featured more sophisticated styling while maintaining the Art & Science design elements. Engine options expanded to include a 3.0L V6 with 270 HP, a 3.6L V6 with 304 HP, and in 2010, a 3.6L twin-turbo V6 producing 556 HP in the CTS-V. The lineup expanded to include coupe and wagon body styles, with the striking coupe particularly enhancing Cadillac's design credentials. The interior saw significant improvements in material quality, design, and technology. The second-generation CTS, particularly the CTS-V, received critical acclaim for its performance and handling, helping establish Cadillac's credibility in the performance luxury segment."
+    end_year: 2014
+    description: "The second-generation CTS grew in size, refinement, and performance, moving more firmly into the mid-size luxury segment. Built on an enhanced version of the Sigma platform (Sigma II), it featured more sophisticated styling while maintaining the Art & Science design elements. Engine options expanded to include a 3.0L V6 with 270 HP, a 3.6L V6 with 304 HP, and in 2010, a 3.6L twin-turbo V6 producing 556 HP in the CTS-V. The lineup expanded to include coupe (2011-2014) and wagon (2010-2014) body styles, with the striking coupe particularly enhancing Cadillac's design credentials. The interior saw significant improvements in material quality, design, and technology. The second-generation CTS, particularly the CTS-V, received critical acclaim for its performance and handling, helping establish Cadillac's credibility in the performance luxury segment. The second-generation CTS-V was marketed through 2014, concurrent with the third generation standard sedan."
 
   - name: "Third Generation"
     start_year: 2014


### PR DESCRIPTION
- Updated second generation end_year from 2013 to 2014 (reflecting concurrent marketing with third generation)
- Added Wikipedia reference to generations.yaml
- Clarified platform details (Sigma II platform code)
- Noted coupe and wagon availability periods for second generation
- Updated README.md with standard template

Evidence from Wikipedia: Second-generation CTS was "marketed through 2014, concurrent with the third generation standard sedan" (https://en.wikipedia.org/wiki/Cadillac_CTS section "CTS-V (2009-2014)")

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
